### PR TITLE
Document how to install dependent packages in Arduino IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This library is available on Arduino Library Registry. You can find this in Ardu
 
 ## Dependencies
 
-Please refer to the `lib_deps` section in [platformio.ini](./platformio.ini).
+Please refer to the `lib_deps` section in [platformio.ini](./platformio.ini). If you use Arduino IDE, please install the packages from Arduino Library Manager.
 
 ## Tips
 


### PR DESCRIPTION
There was a guy who could not find where to install the dependent package (at that time, it was [WireGuard-ESP32-Arduino](https://github.com/ciniml/WireGuard-ESP32-Arduino)). I'd like to add the guide for Arduino IDE users.